### PR TITLE
refactor: ♻️  move wip`text_snippet` to config `body-header`

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -10,6 +10,7 @@ book:
   date: last-modified
   repo-url: https://github.com/rostools/REPO
   site-url: https://REPO.rostools.org/
+  body-header: "{{< text_snippet wip >}}"
   chapters:
     - index.qmd
     - part: "Preamble"

--- a/appendix/social.qmd
+++ b/appendix/social.qmd
@@ -1,7 +1,5 @@
 # Networking and social activities
 
-{{< include ../includes/_wip.qmd >}}
-
 ## Day 1 {#social-day-1 .unnumbered}
 
 ## Day 2 {#social-day-2 .unnumbered}

--- a/includes/_wip.qmd
+++ b/includes/_wip.qmd
@@ -1,3 +1,0 @@
-::: callout-warning
-🚧 This section is being actively worked on. 🚧
-:::

--- a/index.qmd
+++ b/index.qmd
@@ -1,7 +1,5 @@
 # Welcome!
 
-{{< include includes/_wip.qmd >}}
-
 ## Test the shortcodes
 
 {{< text_snippet review_note >}}

--- a/preamble/pre-course.qmd
+++ b/preamble/pre-course.qmd
@@ -1,7 +1,5 @@
 # Pre-course tasks {#sec-pre-course}
 
-{{< include ../includes/_wip.qmd >}}
-
 ```{r}
 #| echo: false
 # To trigger downlit.

--- a/preamble/schedule.qmd
+++ b/preamble/schedule.qmd
@@ -1,7 +1,5 @@
 # Schedule {#sec-schedule}
 
-{{< include ../includes/_wip.qmd >}}
-
 The course is structured as a series of participatory live-coding
 sessions interspersed with hands-on exercises and group work, using
 either a practice dataset or some other real-world dataset. There are

--- a/preamble/syllabus.qmd
+++ b/preamble/syllabus.qmd
@@ -1,7 +1,5 @@
 # Syllabus {#sec-syllabus}
 
-{{< include ../includes/_wip.qmd >}}
-
 Objectives:
 
 -   Item 1

--- a/sessions/introduction.qmd
+++ b/sessions/introduction.qmd
@@ -1,7 +1,5 @@
 # Introduction to course {#sec-introduction}
 
-{{< include ../includes/_wip.qmd >}}
-
 > [**Introduction slides**](../slides/introduction.html)
 
 <div>

--- a/sessions/lesson.qmd
+++ b/sessions/lesson.qmd
@@ -1,7 +1,5 @@
 # TODO: Lesson title here
 
-{{< include ../includes/_wip.qmd >}}
-
 ```{r setup}
 #| include: false
 ```

--- a/sessions/what-next.qmd
+++ b/sessions/what-next.qmd
@@ -1,7 +1,5 @@
 # What next
 
-{{< include ../includes/_wip.qmd >}}
-
 > [**Slides**](../slides/introduction.html)
 
 <div>


### PR DESCRIPTION
## Description

This PR moves the wip `text_snippet` to the `body-header` in `_quarto.yml` and removes the `includes/_wip` from individual docs and removes the `_wip` file itself.

<!-- Please delete as appropriate: -->
This PR needs a quick review.

## Checklist

- [X] Ran `just run-all`
