### PR TITLE
fix: change `includes/` to `text_snippet` in reading task code snippet

### DIFF
--- a/.vscode/json.code-snippets
+++ b/.vscode/json.code-snippets
@@ -62,7 +62,7 @@
       "",
       "${1:Text body}",
       "",
-      "{{< include ../includes/_sticky_up.qmd >}}",
+      "{{< text_snippet sticky_up >}}",
       ":::",
     ],
     "description": "Insert reading task section."


### PR DESCRIPTION
## Description

Not entirely sure if these code snippets are even used?

<!-- Please delete as appropriate: -->
This PR needs a quick review.

## Checklist

- [X] Ran `just run-all`
