### PR TITLE
fix: :pencil2: "event" -> "workshop"

### DIFF
--- a/_extensions/r3-theme/includes/code-of-conduct.qmd
+++ b/_extensions/r3-theme/includes/code-of-conduct.qmd
@@ -82,7 +82,7 @@ organizers, teachers, or helpers may take any action they deem
 appropriate, including warning the offender or expulsion from the
 workshop.
 
-Thank you for helping make this a welcoming, friendly event for all
+Thank you for helping make this a welcoming, friendly workshop for all
 :smile:
 
 ::: {.callout-note appearance="default"}


### PR DESCRIPTION
## Description

It’s probably mostly, if not always, workshops and not events :)

<!-- Please delete as appropriate: -->
This PR needs a quick review.

## Checklist

- [ ] Formatted Markdown
- [ ] Ran `just run-all`
